### PR TITLE
Adds BlenderDataFactory

### DIFF
--- a/src/blenderdata/__init__.py
+++ b/src/blenderdata/__init__.py
@@ -1,5 +1,6 @@
 from .blenderdatabaseclass import BlenderDataBaseClass
-from .blenderobject import BlenderObject, blender_object_generator
+from .blenderobject import BlenderObject
 from .blenderobjectprotocol import BlenderObjectProtocol
 from .blendermesh import BlenderMesh
 from .blendermeshprotocol import BlenderMeshProtocol
+from .blenderdatafactory import BlenderDataFactory

--- a/src/blenderdata/blenderdatafactory.py
+++ b/src/blenderdata/blenderdatafactory.py
@@ -1,0 +1,38 @@
+from typing import Callable, Generator, Iterable
+
+from .blendermesh import BlenderMesh
+from .blendermeshprotocol import BlenderMeshProtocol
+from .blenderobject import BlenderObject
+from .blenderobjectprotocol import BlenderObjectProtocol
+
+
+class BlenderDataFactory:
+    @classmethod
+    def get_blender_object(cls, obj: BlenderObjectProtocol) -> BlenderObject:
+        data_function: dict[str, Callable] = {
+            "MESH": cls.get_blender_mesh
+        }
+        new_object: BlenderObject = BlenderObject()
+        new_object.name = obj.name
+        new_object.type = obj.type
+        new_object.data = data_function.get(obj.type, lambda _: None)(obj)
+        return new_object
+
+    @classmethod
+    def get_blender_mesh(cls, mesh: BlenderMeshProtocol) -> BlenderMesh:
+        new_mesh: BlenderMesh = BlenderMesh()
+        new_mesh.name = mesh.name
+        return new_mesh
+
+    @classmethod
+    def blender_object_generator(cls, objects: Iterable[BlenderObjectProtocol]) -> Generator[BlenderObject, None, None]:
+        """Generate BlenderObjects from an iterable with objects that implement BlenderObjectProtocol
+         (e.g. bpy.data.Objects).
+
+         :raises TypeError: Object in iterable doesn't implement BlenderObjectProtocol.
+         """
+        for obj in objects:
+            if not isinstance(obj, BlenderObjectProtocol):
+                raise TypeError
+            new_object: BlenderObject = cls.get_blender_object(obj)
+            yield new_object

--- a/src/blenderdata/blenderobject.py
+++ b/src/blenderdata/blenderobject.py
@@ -1,8 +1,7 @@
-from typing import Any, Generator, Iterable
+from typing import Any
 
 from . import utils
 from .blenderdatabaseclass import BlenderDataBaseClass
-from .blenderobjectprotocol import BlenderObjectProtocol
 from .blendermeshprotocol import BlenderMeshProtocol
 
 
@@ -43,7 +42,7 @@ class BlenderObject(BlenderDataBaseClass):
 
     @property
     def dict(self) -> dict[str, Any]:
-        data: str | None = (None if self.type == "EMPTY" else self.data.name)
+        data: str | None = (None if self.data is None else self.data.name)
         return {
             self.name: {
                 "type": self.type,
@@ -52,15 +51,3 @@ class BlenderObject(BlenderDataBaseClass):
                 "material_slots": self.material_slots
             }
         }
-
-    def init_from_object(self, obj: BlenderObjectProtocol):
-        self.name = obj.name
-        self.type = obj.type
-        self.data = obj.data
-
-
-def blender_object_generator(objects: Iterable) -> Generator[BlenderObject, None, None]:
-    for obj in objects:
-        blender_object: BlenderObject = BlenderObject()
-        blender_object.init_from_object(obj)
-        yield blender_object

--- a/src/tests/test_blenderdatafactory.py
+++ b/src/tests/test_blenderdatafactory.py
@@ -1,0 +1,59 @@
+from random import choice
+from unittest import TestCase
+
+from blenderdata import BlenderDataFactory, BlenderMesh, BlenderObject
+
+
+class TestBlenderDataFactory(TestCase):
+    objects: list[BlenderObject]
+    new_objects: list[BlenderObject]
+    names: list[str] = [f"Test{i}" for i in range(9)]
+
+    def setUp(self) -> None:
+        self.objects = []
+        for name in self.names:
+            blender_object: BlenderObject = BlenderObject()
+            blender_object.name = name
+            blender_object.type = choice(["EMPTY", "MESH"])
+            if blender_object.type == "MESH":
+                mesh: BlenderMesh = BlenderMesh()
+                mesh.name = name
+                blender_object.data = mesh
+            self.objects.append(blender_object)
+        self.new_objects = [obj for obj in BlenderDataFactory.blender_object_generator(self.objects)]
+
+    def test_generator(self):
+        with self.subTest("Objects are unique"):
+            for idx in range(len(self.objects)):
+                self.assertIsNot(self.objects[idx], self.new_objects[idx])
+        with self.subTest("Objects in iterable must implement BlenderObjectProtocol (raises TypeError)"):
+            mesh: BlenderMesh = BlenderMesh()
+            mesh.name = "i_should_fail"
+            with self.assertRaises(TypeError):
+                a = next(BlenderDataFactory.blender_object_generator([mesh]))
+
+    def test_get_blender_object(self):
+        with self.subTest("Returned object has correct data"):
+            for idx in range(len(self.objects)):
+                original: BlenderObject = self.objects[idx]
+                created: BlenderObject = self.new_objects[idx]
+                self.assertEqual(original.name, created.name)
+                self.assertEqual(original.type, created.type)
+                if original.data is None:
+                    continue
+                self.assertIsNot(original.data, created.data)
+        with self.subTest("Returned object is unique"):
+            # NOTE: If this fails, the generator most likely fails as well
+            for idx in range(len(self.objects)):
+                original: BlenderObject = self.objects[idx]
+                created: BlenderObject = self.new_objects[idx]
+                self.assertIsNot(original, created)
+
+    def test_get_blender_mesh(self):
+        mesh: BlenderMesh = BlenderMesh()
+        mesh.name = "test.mesh"
+        new_mesh: BlenderMesh = BlenderDataFactory.get_blender_mesh(mesh)
+        with self.subTest("Returned mesh has correct data"):
+            self.assertEqual(mesh.name, new_mesh.name)
+        with self.subTest("Returned mesh is a unique object"):
+            self.assertIsNot(mesh, new_mesh)

--- a/src/tests/test_blenderobject.py
+++ b/src/tests/test_blenderobject.py
@@ -1,7 +1,7 @@
 from typing import Any
 from unittest import TestCase
 
-from blenderdata import BlenderMesh, BlenderObject, blender_object_generator, BlenderObjectProtocol
+from blenderdata import BlenderMesh, BlenderObject, BlenderObjectProtocol
 
 
 class TestBlenderObject(TestCase):
@@ -29,15 +29,6 @@ class TestBlenderObject(TestCase):
             self.assertEqual(None, self.blender_object.data)
             self.assertEqual([], self.blender_object.modifiers)
             self.assertEqual([], self.blender_object.material_slots)
-        with self.subTest("Object can be initialized by another object compliant with BlenderObjectProtocol"):
-            bl_obj: BlenderObject = BlenderObject()
-            bl_obj.name = "test"
-            bl_obj.type = "MESH"
-            bl_obj.data = self.mesh
-            self.blender_object.init_from_object(bl_obj)
-            self.assertEqual("test", self.blender_object.name)
-            self.assertEqual("MESH", self.blender_object.type)
-            self.assertEqual(self.mesh, self.blender_object.data)
 
     def test_type_property(self):
         with self.subTest("Setter: Type must be str (raises TypeError)"):
@@ -67,21 +58,3 @@ class TestBlenderObject(TestCase):
             self.mock_dict[bl_obj.name]["type"] = bl_obj.type
             self.mock_dict[bl_obj.name]["data"] = bl_obj.data.name
             self.assertEqual(self.mock_dict, bl_obj.dict)
-
-
-class TestBlenderObjectGenerator(TestCase):
-    objects: list[BlenderObject]
-    names: list[str] = [f"Test{i}" for i in range(9)]
-
-    def setUp(self) -> None:
-        self.objects = []
-        for name in self.names:
-            blender_object: BlenderObject = BlenderObject()
-            blender_object.name = name
-            blender_object.type = "EMPTY"
-            self.objects.append(blender_object)
-
-    def test_generator(self):
-        with self.subTest("Names match"):
-            names: list[str] = [obj.name for obj in blender_object_generator(self.objects)]
-            self.assertEqual(names, self.names)


### PR DESCRIPTION
BlenderDataFactory can be used to generate BlenderObjects and BlenderMeshes.

Takes BlenderObject generating methods and functions to itself.

To be extended in the future.

Closes #7