### PR TITLE
BlenderDataDict

### DIFF
--- a/src/blenderdata/__init__.py
+++ b/src/blenderdata/__init__.py
@@ -4,3 +4,4 @@ from .blenderobjectprotocol import BlenderObjectProtocol
 from .blendermesh import BlenderMesh
 from .blendermeshprotocol import BlenderMeshProtocol
 from .blenderdatafactory import BlenderDataFactory
+from .blenderdatadict import BlenderDataDict

--- a/src/blenderdata/blenderdatabaseclass.py
+++ b/src/blenderdata/blenderdatabaseclass.py
@@ -17,6 +17,3 @@ class BlenderDataBaseClass:
     @name.setter
     def name(self, name: str):
         self.__name = utils.validate_string(name)
-
-    @property
-    def dict(self) -> dict[str, Any]: raise NotImplementedError

--- a/src/blenderdata/blenderdatadict.py
+++ b/src/blenderdata/blenderdatadict.py
@@ -1,2 +1,7 @@
+from typing import Any
+
+
 class BlenderDataDict:
-    pass
+    @classmethod
+    def get_dict(cls, obj: Any) -> dict:
+        return {}

--- a/src/blenderdata/blenderdatadict.py
+++ b/src/blenderdata/blenderdatadict.py
@@ -1,0 +1,2 @@
+class BlenderDataDict:
+    pass

--- a/src/blenderdata/blenderdatadict.py
+++ b/src/blenderdata/blenderdatadict.py
@@ -1,5 +1,6 @@
 from typing import Any, Callable
 
+from . import utils
 from .blendermeshprotocol import BlenderMeshProtocol
 from .blenderobjectprotocol import BlenderObjectProtocol
 
@@ -12,7 +13,7 @@ class BlenderDataDict:
             "Mesh": cls.get_mesh_dict
         }
         data: dict = {}
-        obj_type: str = type(obj).__name__
+        obj_type: str = utils.get_class_name(obj)
         for T, func in __types.items():
             if not obj_type.endswith(T):
                 continue

--- a/src/blenderdata/blenderdatadict.py
+++ b/src/blenderdata/blenderdatadict.py
@@ -21,8 +21,16 @@ class BlenderDataDict:
 
     @classmethod
     def get_object_dict(cls, obj: BlenderObjectProtocol) -> dict[str, Any]:
-        pass
+        data: str | None = (None if obj.data is None else obj.data.name)
+        return {
+            obj.name: {
+                "type": obj.type,
+                "data": data,
+                "modifiers": [mod.type for mod in obj.modifiers],
+                "material_slots": [mat.name for mat in obj.material_slots]
+            }
+        }
 
     @classmethod
     def get_mesh_dict(cls, mesh: BlenderMeshProtocol) -> dict[str, Any]:
-        pass
+        return {mesh.name: {}}

--- a/src/blenderdata/blenderdatadict.py
+++ b/src/blenderdata/blenderdatadict.py
@@ -1,7 +1,28 @@
-from typing import Any
+from typing import Any, Callable
+
+from .blendermeshprotocol import BlenderMeshProtocol
+from .blenderobjectprotocol import BlenderObjectProtocol
 
 
 class BlenderDataDict:
     @classmethod
     def get_dict(cls, obj: Any) -> dict:
-        return {}
+        __types: dict[str, Callable[..., dict[str, Any]]] = {
+            "Object": cls.get_object_dict,
+            "Mesh": cls.get_mesh_dict
+        }
+        data: dict = {}
+        obj_type: str = type(obj).__name__
+        for T, func in __types.items():
+            if not obj_type.endswith(T):
+                continue
+            data = func(obj)
+        return data
+
+    @classmethod
+    def get_object_dict(cls, obj: BlenderObjectProtocol) -> dict[str, Any]:
+        pass
+
+    @classmethod
+    def get_mesh_dict(cls, mesh: BlenderMeshProtocol) -> dict[str, Any]:
+        pass

--- a/src/blenderdata/blendermesh.py
+++ b/src/blenderdata/blendermesh.py
@@ -6,7 +6,3 @@ from .blenderdatabaseclass import BlenderDataBaseClass
 class BlenderMesh(BlenderDataBaseClass):
     def __init__(self):
         super().__init__()
-
-    @property
-    def dict(self) -> dict[str, Any]:
-        return {self.name: {}}

--- a/src/blenderdata/blenderobject.py
+++ b/src/blenderdata/blenderobject.py
@@ -39,15 +39,3 @@ class BlenderObject(BlenderDataBaseClass):
     @property
     def material_slots(self) -> list[str | int]:
         return self.__material_slots
-
-    @property
-    def dict(self) -> dict[str, Any]:
-        data: str | None = (None if self.data is None else self.data.name)
-        return {
-            self.name: {
-                "type": self.type,
-                "data": data,
-                "modifiers": self.modifiers,
-                "material_slots": self.material_slots
-            }
-        }

--- a/src/blenderdata/utils.py
+++ b/src/blenderdata/utils.py
@@ -1,3 +1,6 @@
+from typing import Any
+
+
 def validate_string(string: str) -> str:
     """Validates the type and value of a given string.
 
@@ -10,3 +13,7 @@ def validate_string(string: str) -> str:
     if string == "":
         raise ValueError("Argument can't be an empty string")
     return string
+
+
+def get_class_name(obj: Any) -> str:
+    return type(obj).__name__

--- a/src/main.py
+++ b/src/main.py
@@ -32,15 +32,14 @@ class Main:
 
     def run(self):
         self.__get_root_path()
-        from blenderdata import BlenderDataFactory, BlenderObject
+        from blenderdata import BlenderDataDict, BlenderDataFactory, BlenderObject
 
         for obj in bpy.data.objects:
             logging.debug(f"Adding object '{obj.name}'")
-            bd_obj: BlenderObject = BlenderDataFactory.get_blender_object(obj)
-            self.objects |= bd_obj.dict
+            self.objects |= BlenderDataDict.get_dict(obj)
             if obj.type != "MESH":
                 continue
-            self.meshes |= bd_obj.data.dict
+            self.meshes |= BlenderDataDict.get_dict(obj.data)
 
         json_path: str = os.path.join(self.root, "output.json")
         json_contents: dict[str, dict] = {

--- a/src/tests/test_blenderdatabaseclass.py
+++ b/src/tests/test_blenderdatabaseclass.py
@@ -20,8 +20,3 @@ class TestBlenderDataBaseClass(TestCase):
             name: str = "test"
             self.data.name = name
             self.assertEqual(name, self.data.name)
-
-    def test_dict_property(self):
-        with self.subTest("dict property is not implemented (raises NotImplementedError"):
-            with self.assertRaises(NotImplementedError):
-                a = self.data.dict

--- a/src/tests/test_blenderdatadict.py
+++ b/src/tests/test_blenderdatadict.py
@@ -1,8 +1,26 @@
 from unittest import TestCase
 
-from blenderdata import BlenderDataDict
+from blenderdata import BlenderDataDict, BlenderMesh, BlenderObject
 
 
 class TestBlenderDataDict(TestCase):
+    blender_object: BlenderObject
+    mesh: BlenderMesh
+
+    def setUp(self) -> None:
+        self.blender_object = BlenderObject()
+        self.mesh = BlenderMesh()
+
     def test_get_dict(self):
-        self.assertEqual({}, BlenderDataDict.get_dict(None))
+        with self.subTest("None returns an empty dict"):
+            self.assertEqual({}, BlenderDataDict.get_dict(None))
+        with self.subTest("BlenderObject returns a correct dict"):
+            self.fail()
+        with self.subTest("BlenderMesh returns a correct dict"):
+            self.fail()
+
+    def test_get_object_dict(self):
+        self.fail()
+
+    def test_get_mesh_dict(self):
+        self.fail()

--- a/src/tests/test_blenderdatadict.py
+++ b/src/tests/test_blenderdatadict.py
@@ -4,4 +4,5 @@ from blenderdata import BlenderDataDict
 
 
 class TestBlenderDataDict(TestCase):
-    pass
+    def test_get_dict(self):
+        self.assertEqual({}, BlenderDataDict.get_dict(None))

--- a/src/tests/test_blenderdatadict.py
+++ b/src/tests/test_blenderdatadict.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from unittest import TestCase
+from unittest import mock, TestCase
 
 from blenderdata import BlenderDataDict, BlenderMesh, BlenderObject
 
@@ -34,6 +34,14 @@ class TestBlenderDataDict(TestCase):
             self.assertEqual(self.object_dict, BlenderDataDict.get_dict(self.blender_object))
         with self.subTest("BlenderMesh returns a correct dict"):
             self.assertEqual(self.mesh_dict, BlenderDataDict.get_dict(self.mesh))
+        with self.subTest("bpy.types.Object returns a correct dict"):
+            with mock.patch("blenderdata.utils.get_class_name") as mock_class:
+                mock_class.return_value = "bpy.types.Object"
+                self.assertEqual(self.object_dict, BlenderDataDict.get_dict(self.blender_object))
+        with self.subTest("bpy.types.Mesh returns a correct dict"):
+            with mock.patch("blenderdata.utils.get_class_name") as mock_class:
+                mock_class.return_value = "bpy.types.Mesh"
+                self.assertEqual(self.mesh_dict, BlenderDataDict.get_dict(self.mesh))
 
     def test_get_object_dict(self):
         bl_obj: BlenderObject = BlenderObject()

--- a/src/tests/test_blenderdatadict.py
+++ b/src/tests/test_blenderdatadict.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from unittest import TestCase
 
 from blenderdata import BlenderDataDict, BlenderMesh, BlenderObject
@@ -7,20 +9,44 @@ class TestBlenderDataDict(TestCase):
     blender_object: BlenderObject
     mesh: BlenderMesh
 
+    object_dict: dict[str, Any]
+    mesh_dict: dict[str, Any] = {"test": {}}
+
     def setUp(self) -> None:
         self.blender_object = BlenderObject()
+        self.blender_object.name = "test"
+        self.blender_object.type = "EMPTY"
         self.mesh = BlenderMesh()
+        self.mesh.name = "test"
+        self.object_dict: dict[str, Any] = {
+            "test": {
+                "type": "EMPTY",
+                "data": None,
+                "modifiers": [],
+                "material_slots": []
+            }
+        }
 
     def test_get_dict(self):
         with self.subTest("None returns an empty dict"):
             self.assertEqual({}, BlenderDataDict.get_dict(None))
         with self.subTest("BlenderObject returns a correct dict"):
-            self.fail()
+            self.assertEqual(self.object_dict, BlenderDataDict.get_dict(self.blender_object))
         with self.subTest("BlenderMesh returns a correct dict"):
-            self.fail()
+            self.assertEqual(self.mesh_dict, BlenderDataDict.get_dict(self.mesh))
 
     def test_get_object_dict(self):
-        self.fail()
+        bl_obj: BlenderObject = BlenderObject()
+        bl_obj.name = "test"
+        bl_obj.type = self.object_dict[bl_obj.name]["type"]
+        with self.subTest("When object type == 'EMPTY', data is None"):
+            self.assertEqual(self.object_dict, BlenderDataDict.get_object_dict(bl_obj))
+        with self.subTest("When object type != 'EMPTY', data is str"):
+            bl_obj.type = "MESH"
+            bl_obj.data = self.mesh
+            self.object_dict[bl_obj.name]["type"] = bl_obj.type
+            self.object_dict[bl_obj.name]["data"] = bl_obj.data.name
+            self.assertEqual(self.object_dict, BlenderDataDict.get_object_dict(bl_obj))
 
     def test_get_mesh_dict(self):
-        self.fail()
+        self.assertEqual({self.mesh.name: {}}, BlenderDataDict.get_mesh_dict(self.mesh))

--- a/src/tests/test_blenderdatadict.py
+++ b/src/tests/test_blenderdatadict.py
@@ -1,0 +1,7 @@
+from unittest import TestCase
+
+from blenderdata import BlenderDataDict
+
+
+class TestBlenderDataDict(TestCase):
+    pass

--- a/src/tests/test_blendermesh.py
+++ b/src/tests/test_blendermesh.py
@@ -1,19 +1,13 @@
-from typing import Any
 from unittest import TestCase
 
 from blenderdata import BlenderMesh, BlenderMeshProtocol
 
 
 class TestBlenderMesh(TestCase):
-    mock_dict: dict[str, Any] = {"test": {}}
     mesh: BlenderMesh
 
     def setUp(self) -> None:
         self.mesh = BlenderMesh()
-
-    def test_dict(self):
-        self.mesh.name = "test"
-        self.assertEqual(self.mock_dict, self.mesh.dict)
 
     def test_protocol_implementation(self):
         with self.subTest("BlenderMesh implements BlenderMeshProtocol"):

--- a/src/tests/test_blenderobject.py
+++ b/src/tests/test_blenderobject.py
@@ -1,4 +1,3 @@
-from typing import Any
 from unittest import TestCase
 
 from blenderdata import BlenderMesh, BlenderObject, BlenderObjectProtocol
@@ -7,20 +6,11 @@ from blenderdata import BlenderMesh, BlenderObject, BlenderObjectProtocol
 class TestBlenderObject(TestCase):
     blender_object: BlenderObject
     mesh: BlenderMesh
-    mock_dict: dict[str, Any]
 
     def setUp(self) -> None:
         self.blender_object = BlenderObject()
         self.mesh = BlenderMesh()
         self.mesh.name = "test"
-        self.mock_dict: dict[str, Any] = {
-            "test": {
-                "type": "EMPTY",
-                "data": None,
-                "modifiers": [],
-                "material_slots": []
-            }
-        }
 
     def test_initialization(self):
         with self.subTest("Initialized object is empty"):
@@ -45,16 +35,3 @@ class TestBlenderObject(TestCase):
     def test_protocol_implementation(self):
         with self.subTest("BlenderObject implements BlenderObjectProtocol"):
             self.assertTrue(isinstance(self.blender_object, BlenderObjectProtocol))
-
-    def test_dict_property(self):
-        bl_obj: BlenderObject = BlenderObject()
-        bl_obj.name = "test"
-        bl_obj.type = self.mock_dict[bl_obj.name]["type"]
-        with self.subTest("When object type == 'EMPTY', data is None"):
-            self.assertEqual(self.mock_dict, bl_obj.dict)
-        with self.subTest("When object type != 'EMPTY', data is str"):
-            bl_obj.type = "MESH"
-            bl_obj.data = self.mesh
-            self.mock_dict[bl_obj.name]["type"] = bl_obj.type
-            self.mock_dict[bl_obj.name]["data"] = bl_obj.data.name
-            self.assertEqual(self.mock_dict, bl_obj.dict)


### PR DESCRIPTION
- Removes dict property from BlenderDataBaseClass and children
- Adds BlenderDataDict static class to handle creation of appropriate dicts
  - Allows creation of dicts from bpy.types or blenderdata objects

This change might become the heart of the data dumping part of the tool. Building intermediate data structures during the dumping process is unnecessary.

Closes #8 